### PR TITLE
Sta cross-referenties toe naar het core document

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,4 +12,9 @@ jobs:
   check:
     needs: build
     name: Check
-    uses: Logius-standaarden/Automatisering/.github/workflows/check.yml@main    
+    uses: Logius-standaarden/Automatisering/.github/workflows/check.yml@main
+  publish:
+    needs: build
+    name: Publish (Logius)
+    uses: Logius-standaarden/Automatisering/.github/workflows/publish.yml@main
+    secrets: inherit    

--- a/ch02.md
+++ b/ch02.md
@@ -16,7 +16,7 @@ Referentie uit locale lijst [[SemVer]]. Lijst staat in `organisation-config.js`.
 We gebruiken een <a>definitie</a> om een woord te omschrijven.
 
 In een extensie kunnen ook referenties worden toegevoegd naar definities van de core.
-Bijvoorbeeld {{Logboek}} of {{Betrokkene}}.
+Bijvoorbeeld [=Logboek=] of [=Betrokkene=].
 
 ## Optioneel
 

--- a/ch02.md
+++ b/ch02.md
@@ -15,6 +15,9 @@ Referentie uit locale lijst [[SemVer]]. Lijst staat in `organisation-config.js`.
 
 We gebruiken een <a>definitie</a> om een woord te omschrijven.
 
+In een extensie kunnen ook referenties worden toegevoegd naar definities van de core.
+Bijvoorbeeld {{Logboek}} of {{Betrokkene}}.
+
 ## Optioneel
 
 De onderstaande secties (_Conformiteit_ e.d.) zijn optioneel, zie `index.html`:

--- a/js/config.js
+++ b/js/config.js
@@ -38,4 +38,8 @@ let respecConfig = {
           uri: "template.pdf",
       },
   ],
+
+  xref: {
+    url: new URL('js/xrefs.json')
+  },
 };

--- a/js/config.js
+++ b/js/config.js
@@ -40,6 +40,6 @@ let respecConfig = {
   ],
 
   xref: {
-    url: new URL('js/xrefs.json', window.location)
+    url: './js/xrefs.json',
   },
 };

--- a/js/config.js
+++ b/js/config.js
@@ -40,6 +40,6 @@ let respecConfig = {
   ],
 
   xref: {
-    url: new URL('js/xrefs.json')
+    url: new URL('js/xrefs.json', window.location)
   },
 };

--- a/js/xrefs.json
+++ b/js/xrefs.json
@@ -9,7 +9,7 @@
         },
         "result": [
           {
-            "shortname": "logboek",
+            "shortname": "betrokkene",
             "type": "dfn",
             "normative": true,
             "uri": "https://logius-standaarden.github.io/logboek-dataverwerkingen/#dfn-betrokkenen"

--- a/js/xrefs.json
+++ b/js/xrefs.json
@@ -9,7 +9,7 @@
         },
         "result": [
           {
-            "shortname": "betrokkene",
+            "shortname": "local-1",
             "type": "dfn",
             "normative": true,
             "uri": "https://logius-standaarden.github.io/logboek-dataverwerkingen/#dfn-betrokkenen"
@@ -25,7 +25,7 @@
         },
         "result": [
           {
-            "shortname": "logboek",
+            "shortname": "local-2",
             "type": "dfn",
             "normative": true,
             "uri": "https://logius-standaarden.github.io/logboek-dataverwerkingen/#dfn-logboeken"

--- a/js/xrefs.json
+++ b/js/xrefs.json
@@ -1,11 +1,11 @@
 {
     "results": [
       {
-        "id": "ab7db5bcda5172f65990774c08b2d5623d0ca4d9",
+        "id": "1",
         "query": {
           "term": "Betrokkene",
           "types": ["_CONCEPT_"],
-          "id": "ab7db5bcda5172f65990774c08b2d5623d0ca4d9"
+          "id": "1"
         },
         "result": [
           {
@@ -17,11 +17,11 @@
         ]
       },
       {
-        "id": "ab7db5bcda5172f65990774c08b2d5623d0ca4d9",
+        "id": "2",
         "query": {
           "term": "Logboek",
           "types": ["_CONCEPT_"],
-          "id": "ab7db5bcda5172f65990774c08b2d5623d0ca4d9"
+          "id": "2"
         },
         "result": [
           {

--- a/js/xrefs.json
+++ b/js/xrefs.json
@@ -3,7 +3,7 @@
       {
         "id": "1",
         "query": {
-          "term": "Betrokkene",
+          "term": "betrokkene",
           "types": ["_CONCEPT_"],
           "id": "1"
         },
@@ -19,7 +19,7 @@
       {
         "id": "2",
         "query": {
-          "term": "Logboek",
+          "term": "logboek",
           "types": ["_CONCEPT_"],
           "id": "2"
         },

--- a/js/xrefs.json
+++ b/js/xrefs.json
@@ -1,0 +1,36 @@
+{
+    "results": [
+      {
+        "id": "ab7db5bcda5172f65990774c08b2d5623d0ca4d9",
+        "query": {
+          "term": "Betrokkene",
+          "types": ["_CONCEPT_"],
+          "id": "ab7db5bcda5172f65990774c08b2d5623d0ca4d9"
+        },
+        "result": [
+          {
+            "shortname": "logboek",
+            "type": "dfn",
+            "normative": true,
+            "uri": "https://logius-standaarden.github.io/logboek-dataverwerkingen/#dfn-betrokkenen"
+          }
+        ]
+      },
+      {
+        "id": "ab7db5bcda5172f65990774c08b2d5623d0ca4d9",
+        "query": {
+          "term": "Logboek",
+          "types": ["_CONCEPT_"],
+          "id": "ab7db5bcda5172f65990774c08b2d5623d0ca4d9"
+        },
+        "result": [
+          {
+            "shortname": "logboek",
+            "type": "dfn",
+            "normative": true,
+            "uri": "https://logius-standaarden.github.io/logboek-dataverwerkingen/#dfn-logboeken"
+          }
+        ]
+      }
+    ]
+}


### PR DESCRIPTION
Hiermee instrueren we Respec om de definities van het Logboek core
document te gebruiken. Deze zijn manueel gedefinieerd en onvolledig
op dit moment. Het vereist dus synchronisatie naar de extensie voordat
een definitie mag worden gerefereerd.

De referentie is zoals iedere andere referentie, waarbij hij dus gaat
linken naar het core document.