### PR TITLE
Fix attributes veld

### DIFF
--- a/sections/ch01.md
+++ b/sections/ch01.md
@@ -63,7 +63,7 @@ Dit is enkel een voorbeeld van als er gebruik wordt gemaakt van twee extensies, 
 
 #### Namespaces Key
 
-In de core standaard is de veld `resource` opgebouwd uit een lijst `attributes` met *KeyValue pairs* in een namespace met prefix `dpl.` (data processing log). Het is **verplicht** in de extensie om elke key te beschrijven in het begin met de prefix `dpl.extensienaam`.
+In de core standaard is het veld `attributes` een object opgebouwd uit velden in een namespace met prefix `dpl.` (data processing log). Het is **verplicht** in de extensie om elke key te beschrijven in het begin met de prefix `dpl.extensienaam`.
 
 Zo mag een key van de extensie bijvoorbeeld:
 


### PR DESCRIPTION
De attributes moeten niet in resource, maar in attributes zelf

Part of Logius-standaarden/logboek-dataverwerkingen#165